### PR TITLE
haskell.org-theme #footer s/absolute/fixed/

### DIFF
--- a/default_theme/css/haskell.org.css
+++ b/default_theme/css/haskell.org.css
@@ -72,7 +72,7 @@ div#footer {
     text-align: center;
     height: 4em;
     background-color: #323232;
-    position: absolute;
+    position: fixed;
     bottom: 0;
     width: 100%;
     overflow: hidden;

--- a/default_theme/css/haskell.org.css
+++ b/default_theme/css/haskell.org.css
@@ -46,6 +46,7 @@ div#header #navigation a:hover{
 div#content {
   margin-left: 50px;
   margin-right: 50px;
+  margin-bottom: 5.5rem;
 }
 
 div#content h1{


### PR DESCRIPTION
Otherwise the footer won't scroll with the browser-viewport, leaving it stranded in and occluding the middle of a longer blogpost.